### PR TITLE
RA-40-Implement-RecipesList-Caching

### DIFF
--- a/app/src/main/java/com/example/recipesapp/data/CategoriesDao.kt
+++ b/app/src/main/java/com/example/recipesapp/data/CategoriesDao.kt
@@ -18,4 +18,7 @@ interface CategoriesDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCategories(categories: List<Category>)
+
+    @Query("DELETE FROM category")
+    suspend fun clearCategories()
 }

--- a/app/src/main/java/com/example/recipesapp/data/ConvertersUtils.kt
+++ b/app/src/main/java/com/example/recipesapp/data/ConvertersUtils.kt
@@ -1,0 +1,52 @@
+package com.example.recipesapp.data
+
+import android.util.Log
+import androidx.room.TypeConverter
+import com.example.recipesapp.model.Ingredient
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ConvertersUtils {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @TypeConverter
+    fun fromIngredientList(value: List<Ingredient>): String {
+        return try {
+            json.encodeToString(value)
+        } catch (e: Exception) {
+            Log.e("Converters", "Failed to serialize ingredients", e)
+            "[]"
+        }
+    }
+
+    @TypeConverter
+    fun toIngredientList(value: String): List<Ingredient> {
+        return try {
+            json.decodeFromString(value)
+        } catch (e: Exception) {
+            Log.e("Converters", "Failed to deserialize ingredients", e)
+            emptyList()
+        }
+    }
+
+    @TypeConverter
+    fun fromMethodList(value: List<String>): String {
+        return try {
+            json.encodeToString(value)
+        } catch (e: Exception) {
+            Log.e("Converters", "Failed to serialize method", e)
+            "[]"
+        }
+    }
+
+    @TypeConverter
+    fun toMethodList(value: String): List<String> {
+        return try {
+            json.decodeFromString(value)
+        } catch (e: Exception) {
+            Log.e("Converters", "Failed to deserialize method", e)
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/example/recipesapp/data/RecipesDao.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesDao.kt
@@ -1,0 +1,21 @@
+package com.example.recipesapp.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.recipesapp.model.Recipe
+
+@Dao
+interface RecipesDao {
+    @Query("SELECT * FROM recipe WHERE id >= :rangeStart AND id < :rangeEnd")
+    suspend fun getRecipesList(rangeStart: Int, rangeEnd: Int): List<Recipe>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRecipe(recipe: Recipe)
+
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRecipes(recipes: List<Recipe>)
+
+}

--- a/app/src/main/java/com/example/recipesapp/data/RecipesDao.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesDao.kt
@@ -18,4 +18,6 @@ interface RecipesDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRecipes(recipes: List<Recipe>)
 
+    @Query("DELETE FROM recipe")
+    suspend fun clearRecipes()
 }

--- a/app/src/main/java/com/example/recipesapp/data/RecipesDatabase.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesDatabase.kt
@@ -1,6 +1,7 @@
 package com.example.recipesapp.data
 
 import android.content.Context
+import android.util.Log
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -15,16 +16,23 @@ abstract class RecipesDatabase : RoomDatabase() {
         private var INSTANCE: RecipesDatabase? = null
 
         fun getDatabase(context: Context): RecipesDatabase {
-            return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: Room.databaseBuilder(
+            return synchronized(this) {
+                INSTANCE?.let {
+                    Log.e("RRE", "get existing DB(${it.hashCode()})")
+                    it
+                } ?: Room.databaseBuilder(
                     context.applicationContext,
                     RecipesDatabase::class.java,
                     "recipes_database"
-                ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
+                ).fallbackToDestructiveMigration().build().also {
+                    INSTANCE = it
+                    Log.e("RRE", "create DB(${it.hashCode()})")
+                }
             }
         }
     }
 
     abstract fun categoriesDao(): CategoriesDao
     abstract fun recipesListDao(): RecipesDao
+
 }

--- a/app/src/main/java/com/example/recipesapp/data/RecipesDatabase.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesDatabase.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.example.recipesapp.model.Category
+import com.example.recipesapp.model.Recipe
 
-@Database(entities = [Category::class], version = 1)
+@Database(entities = [Category::class, Recipe::class], version = 2)
+@TypeConverters(ConvertersUtils::class)
 abstract class RecipesDatabase : RoomDatabase() {
     companion object {
         private var INSTANCE: RecipesDatabase? = null
@@ -17,10 +20,11 @@ abstract class RecipesDatabase : RoomDatabase() {
                     context.applicationContext,
                     RecipesDatabase::class.java,
                     "recipes_database"
-                ).build().also { INSTANCE = it }
+                ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
             }
         }
     }
 
     abstract fun categoriesDao(): CategoriesDao
+    abstract fun recipesListDao(): RecipesDao
 }

--- a/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
@@ -100,6 +100,23 @@ class RecipesRepository private constructor(
         }
     }
 
+    suspend fun getCachedRecipes(rangeStart: Int, rangeEnd: Int): RepositoryResult<List<Recipe>> {
+        return try {
+            val recipeList = recipesDatabase.recipesListDao().getRecipesList(rangeStart, rangeEnd)
+            if (recipeList.isNotEmpty()) RepositoryResult.Success(recipeList) else getError()
+        } catch (e: Exception) {
+            RepositoryResult.Error(e)
+        }
+    }
+
+    suspend fun saveRecipeToCache(recipes: List<Recipe>) {
+        try {
+            recipesDatabase.recipesListDao().insertRecipes(recipes)
+        } catch (e: Exception) {
+            Log.e("RRE", "Failed to save recipe to DB ${e.message}")
+        }
+    }
+
     suspend fun getRecipesByIds(ids: HashSet<Int>): RepositoryResult<List<Recipe>> {
         return withContext(dispatcher) {
 

--- a/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
+++ b/app/src/main/java/com/example/recipesapp/data/RecipesRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
+import java.time.LocalDateTime
 
 class RecipesRepository private constructor(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -44,8 +45,24 @@ class RecipesRepository private constructor(
     suspend fun getCategoriesFromCache(): RepositoryResult<List<Category>> {
         return try {
             val categories = recipesDatabase.categoriesDao().getCategories()
-            if (categories.isNotEmpty()) RepositoryResult.Success(categories) else getError()
+            if (categories.isNotEmpty()) {
+                Log.e(
+                    "RRE",
+                    "success get CATEGORIES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time: ${LocalDateTime.now()}"
+                )
+                RepositoryResult.Success(categories)
+            } else {
+                Log.e(
+                    "RRE",
+                    "empty data from  CATEGORIES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+                )
+                getError()
+            }
         } catch (e: Exception) {
+            Log.e(
+                "RRE",
+                "failed get data from  CATEGORIES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+            )
             RepositoryResult.Error(e)
         }
     }
@@ -53,8 +70,12 @@ class RecipesRepository private constructor(
     suspend fun saveCategoriesToCache(categories: List<Category>) {
         try {
             recipesDatabase.categoriesDao().insertCategories(categories)
+            Log.e("RRE", "save categories to DB(${recipesDatabase.hashCode()})  success")
         } catch (e: Exception) {
-            Log.e("RRE", "Failed to save categories to DB ${e.message}")
+            Log.e(
+                "RRE",
+                "failed to save categories to DB(${recipesDatabase.hashCode()}) ${e.message}"
+            )
         }
     }
 
@@ -103,8 +124,24 @@ class RecipesRepository private constructor(
     suspend fun getCachedRecipes(rangeStart: Int, rangeEnd: Int): RepositoryResult<List<Recipe>> {
         return try {
             val recipeList = recipesDatabase.recipesListDao().getRecipesList(rangeStart, rangeEnd)
-            if (recipeList.isNotEmpty()) RepositoryResult.Success(recipeList) else getError()
+            if (recipeList.isNotEmpty()) {
+                Log.e(
+                    "RRE",
+                    "success  get RECIPES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+                )
+                RepositoryResult.Success(recipeList)
+            } else {
+                Log.e(
+                    "RRE",
+                    "empty data from RECIPES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+                )
+                getError()
+            }
         } catch (e: Exception) {
+            Log.e(
+                "RRE",
+                "failed get data from RECIPES data from DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+            )
             RepositoryResult.Error(e)
         }
     }
@@ -112,23 +149,46 @@ class RecipesRepository private constructor(
     suspend fun saveRecipeToCache(recipes: List<Recipe>) {
         try {
             recipesDatabase.recipesListDao().insertRecipes(recipes)
+            Log.e(
+                "RRE",
+                "success  save RECIPES to DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+            )
         } catch (e: Exception) {
-            Log.e("RRE", "Failed to save recipe to DB ${e.message}")
+            Log.e(
+                "RRE",
+                "failed to save recipe to DB DB(${recipesDatabase.hashCode()}) _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()} ___ ${e.message}"
+            )
         }
     }
 
     suspend fun getRecipesByIds(ids: HashSet<Int>): RepositoryResult<List<Recipe>> {
         return withContext(dispatcher) {
-
             try {
+                if (ids.isEmpty()) {
+                    return@withContext RepositoryResult.Success(emptyList<Recipe>())
+                }
                 val response = service.getRecipesByIds(ids.joinToString(",")).execute()
 
                 if (response.isSuccessful) {
                     response.body()?.let {
+                        Log.e(
+                            "RRE",
+                            "success to load recipes from API _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+                        )
                         RepositoryResult.Success(it)
-                    } ?: getError()
+                    } ?: run {
+                        Log.e(
+                            "RRE",
+                            "null query body with recipes from API _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()}"
+                        )
+                        getError()
+                    }
 
                 } else {
+                    Log.e(
+                        "RRE",
+                        "failed load recipes from API _____ thread: ${Thread.currentThread().name} ___ time ${LocalDateTime.now()} ___ e:${response.code()} ${response.message()}"
+                    )
                     getError()
                 }
 

--- a/app/src/main/java/com/example/recipesapp/model/Recipe.kt
+++ b/app/src/main/java/com/example/recipesapp/model/Recipe.kt
@@ -1,13 +1,20 @@
 package com.example.recipesapp.model
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.TypeConverters
+import com.example.recipesapp.data.ConvertersUtils
 import kotlinx.serialization.Serializable
 
 
 @Serializable
+@Entity(tableName = "recipe")
+@TypeConverters(ConvertersUtils::class)
 data class Recipe(
-    val id: Int,
-    val title: String,
-    val ingredients: List<Ingredient>,
-    val method: List<String>,
-    val imageUrl: String?
+    @PrimaryKey val id: Int,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "ingredients") val ingredients: List<Ingredient>,
+    @ColumnInfo(name = "method") val method: List<String>,
+    @ColumnInfo(name = "imageUrl") val imageUrl: String?
 )

--- a/app/src/main/java/com/example/recipesapp/ui/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/categories/CategoriesViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.recipesapp.ui.categories
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -18,12 +19,16 @@ class CategoriesViewModel : ViewModel() {
     fun loadCategories(applicationContext: Context) {
         viewModelScope.launch {
             val repository = RecipesRepository.getInstance(applicationContext)
-
+            Log.e("RRE", "try get CATEGORIES from DB")
             val postVal = when (val cachedCategoriesResult = repository.getCategoriesFromCache()) {
-                is RepositoryResult.Success -> cachedCategoriesResult
+                is RepositoryResult.Success -> {
+
+                    cachedCategoriesResult
+                }
                 is RepositoryResult.Error -> {
                     when (val categoriesApiResult = repository.getCategories()) {
                         is RepositoryResult.Success -> {
+                            Log.e("RRE", "try get CATEGORIES from API")
                             repository.saveCategoriesToCache(categoriesApiResult.data)
                             categoriesApiResult
                         }

--- a/app/src/main/java/com/example/recipesapp/ui/common/RecipeListAdapter.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/common/RecipeListAdapter.kt
@@ -1,9 +1,15 @@
 package com.example.recipesapp.ui.common
 
+import android.graphics.drawable.Drawable
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.engine.GlideException
+import com.bumptech.glide.request.RequestListener
+import com.bumptech.glide.request.target.Target
 import com.example.recipesapp.R
 import com.example.recipesapp.data.RecipesRepository
 import com.example.recipesapp.databinding.ItemRecipeBinding
@@ -23,12 +29,45 @@ class RecipeListAdapter(private var dataSet: List<Recipe>) :
                 .load(RecipesRepository.IMAGE_URL + "${recipe.imageUrl}")
                 .placeholder(R.drawable.img_placeholder)
                 .error(R.drawable.img_error)
+                .listener(object : RequestListener<Drawable> {
+
+                    override fun onResourceReady(
+                        resource: Drawable,
+                        model: Any,
+                        target: Target<Drawable>?,
+                        dataSource: DataSource,
+                        isFirstResource: Boolean
+                    ): Boolean {
+                        return false
+                    }
+
+                    override fun onLoadFailed(
+                        e: GlideException?,
+                        model: Any?,
+                        target: Target<Drawable>,
+                        isFirstResource: Boolean
+                    ): Boolean {
+                        e?.let { exception ->
+                            exception.logRootCauses("RRE")
+                            exception.printStackTrace()
+                        }
+                        Log.e(
+                            "RRE",
+                            "FAIL TO LOAD IMAGE ${recipe.title}: id:${recipe.id} url:${recipe.imageUrl}  error: $e."
+                        )
+
+                        return false
+                    }
+
+
+                })
                 .into(binding.recipeImageView)
 
             binding.recipeImageView.contentDescription =
                 itemView.context.getString(R.string.recipe_header_image_description, recipe.title)
-
         }
+
+
     }
 
     interface OnItemClickListener {

--- a/app/src/main/java/com/example/recipesapp/ui/recipes/recipeslist/RecipeListViewModel.kt
+++ b/app/src/main/java/com/example/recipesapp/ui/recipes/recipeslist/RecipeListViewModel.kt
@@ -2,6 +2,7 @@ package com.example.recipesapp.ui.recipes.recipeslist
 
 import android.app.Application
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -27,14 +28,17 @@ class RecipeListViewModel(application: Application) : AndroidViewModel(applicati
 
             val rangeStart = categoryId * 100
             val rangeEnd = (categoryId + 1) * 100
-
+            Log.e("RRE", "try get RECIPES from DB")
             val postVal =
                 when (val cachedRecipesResult = repository.getCachedRecipes(rangeStart, rangeEnd)) {
-                    is RepositoryResult.Success -> cachedRecipesResult
+                    is RepositoryResult.Success -> {
+                        cachedRecipesResult
+                    }
 
                     is RepositoryResult.Error -> {
-
+                        Log.e("RRE", "try get RECIPES from API")
                         when (val recipesApiResult =
+
                             repository.getRecipesByCategoryId(categoryId)) {
                             is RepositoryResult.Success -> {
 


### PR DESCRIPTION
1. Реализация работы со списком рецептов из БД. 
2. Логику оставил как и для категорий. Если в БД есть данные, то берет оттуда. Если данных нет, то пытается грузить через API и, в случае успеха, записывает их в БД. Что-то в телеге скринкаст отослать не получилось. Но все работает штатно

[Запись экрана от 2025-03-17 09-30-29.webm](https://github.com/user-attachments/assets/0c9bffc3-76b1-4334-818d-2fdbc38f81e3)

3. И нюанс по списку рецептов. У нас в Recipe нет явного "указателя" в какую категорию он входит. Но, судя по приходящим id из api, за категорию отвечает разряд сотен. Поэтому получаю рецепты исходя из этой логике. Считаю что все рецепты вида 1xx относятс к категории с id 1. Для бургеров (id = 0) ,беру рецепты id  которых <100

4. Для упрощения, сохранение в БД полей ingredients и method сделал через сериализацию/десереализзацию, так как room не поддерживает сохранение не примитивов.  Хотя, по хорошему, для ингридиентов надо было бы вводить отдельную таблицу в БД
